### PR TITLE
Add support for always_add_missing_headers in main.cf

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,3 +30,4 @@ enable_postifx_dkim: false
 # Support the setting of the helo name
 enable_smtp_helo_name: false
 postfix_smtp_helo_name: "{{ ansible_fqdn }}"
+enable_always_add_missing_headers: false

--- a/templates/main.cf.j2
+++ b/templates/main.cf.j2
@@ -72,3 +72,6 @@ milter_protocol         = 2
 {% if enable_smtp_helo_name %}
 smtp_helo_name = {{ postfix_smtp_helo_name }}
 {% endif %}
+{% if enable_always_add_missing_headers %}
+always_add_missing_headers = yes
+{% endif %}


### PR DESCRIPTION
When always_add_missing_headers is enabled and Postfix is relaying mail it will add a message-id header if it is missing.
