### PR TITLE
Add FreeBSD support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -51,3 +51,9 @@ enable_always_add_missing_headers: false
 
 # Inet protocols enabled (all, ipv4, ipv6)
 postfix_inet_protocols: all
+
+# Group for configuration files
+postfix_config_group: root
+
+# Path to binaries
+postfix_postmap_path: postmap

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -5,7 +5,7 @@
     dest: "{{ postfix_conf_dir }}/canonical"
     mode: 0644
     owner: root
-    group: "{{postfix_config_group}}"
+    group: "{{ postfix_config_group }}"
   become: true
   notify: restart postfix
   when: enable_sender_canonical|bool
@@ -16,7 +16,7 @@
     dest: "{{ postfix_conf_dir }}/main.cf"
     mode: 0644
     owner: root
-    group: "{{postfix_config_group}}"
+    group: "{{ postfix_config_group }}"
   become: true
   register: postfix
   notify: restart postfix
@@ -30,7 +30,7 @@
     dest: "{{ postfix_conf_dir }}/generic"
     mode: 0644
     owner: root
-    group: "{{postfix_config_group}}"
+    group: "{{ postfix_config_group }}"
   become: true
   register: postfix
   notify: restart postfix
@@ -39,7 +39,7 @@
     - configure_postfix|bool
 
 - name: configure | Rebuilding generic.db
-  command: "{{postfix_postmap_path}} {{postfix_conf_dir}}/generic"
+  command: "{{ postfix_postmap_path }} {{ postfix_conf_dir }}/generic"
   become: true
   notify: restart postfix
   when:

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -5,7 +5,7 @@
     dest: "{{ postfix_conf_dir }}/canonical"
     mode: 0644
     owner: root
-    group: root
+    group: "{{postfix_config_group}}"
   become: true
   notify: restart postfix
   when: enable_sender_canonical|bool
@@ -16,7 +16,7 @@
     dest: "{{ postfix_conf_dir }}/main.cf"
     mode: 0644
     owner: root
-    group: root
+    group: "{{postfix_config_group}}"
   become: true
   register: postfix
   notify: restart postfix
@@ -30,7 +30,7 @@
     dest: "{{ postfix_conf_dir }}/generic"
     mode: 0644
     owner: root
-    group: root
+    group: "{{postfix_config_group}}"
   become: true
   register: postfix
   notify: restart postfix
@@ -38,8 +38,8 @@
     - configure_postfix is defined
     - configure_postfix|bool
 
-- name: configure | Rebuilding generic.db # noqa 503
-  command: postmap /etc/postfix/generic
+- name: configure | Rebuilding generic.db
+  command: "{{postfix_postmap_path}} {{postfix_conf_dir}}/generic"
   become: true
   notify: restart postfix
   when:

--- a/tasks/freebsd.yml
+++ b/tasks/freebsd.yml
@@ -1,0 +1,7 @@
+---
+- name: freebsd | Installing Postfix
+  pkgng:
+    name: postfix
+    state: present
+  become: true
+  when: ansible_os_family == "FreeBSD"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,6 +6,9 @@
 - include_tasks: redhat.yml
   when: ansible_os_family == "RedHat"
 
+- include_tasks: freebsd.yml
+  when: ansible_os_family == "FreeBSD"
+
 - include_tasks: configure.yml
 
 - include_tasks: service.yml


### PR DESCRIPTION
I am already using this role on my debian and ubuntus and I don't want to make a specific one for FreeBSD since the changes are pretty minors.

This basically do the following:
- freebsd install through pkgng ansible module
- made the 'root' group a variable so I can override it (freebsd uses wheel, others might)
- made postmap a variable so I can override it with full path
- fix the 'rebuilding generic.db' path not using `postfix_conf_dir` like the previous template task

I didn't add the requirement to set postfix the default over sendmail + sendmail deactivation, but I can through a `postfix_freebsd_default` variable.