### PR TITLE
Allow overriding myhostname

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -57,3 +57,8 @@ postfix_config_group: root
 
 # Path to binaries
 postfix_postmap_path: postmap
+
+# Hostname if needed to be overriden
+# Is used for `myhostname` and `mydestination`
+postfix_myhostname: "{{ ansible_fqdn }}"
+

--- a/templates/main.cf.j2
+++ b/templates/main.cf.j2
@@ -21,10 +21,10 @@ smtpd_tls_session_cache_database = btree:${data_directory}/smtpd_scache
 smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
 
 smtpd_relay_restrictions = permit_mynetworks permit_sasl_authenticated defer_unauth_destination
-myhostname = {{ansible_fqdn}}
+myhostname = {{ postfix_myhostname }}
 alias_maps = hash:/etc/aliases
 alias_database = hash:/etc/aliases
-mydestination = {{ansible_fqdn}}, localhost
+mydestination = {{ postfix_myhostname }}, localhost
 {% if postfix_relayhost is defined and enable_postfix_relayhost %}
 relayhost = {{postfix_relayhost}}
 {% endif %}


### PR DESCRIPTION
I need to use a specific myhostname for an host or two, this permits to override the `myhostname` and `mydestination` hostname.

Default is still `ansible_fqdn`